### PR TITLE
Update JVM Target to 1.8 for Kotlin projects

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,6 +39,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
@@ -129,7 +133,8 @@ ext {
     // App dependency versions
     appCompatVersion = '1.0.2'
     supportVersion = '1.0.0'
-    playServicesVersion = '16.1.0'
+    playServicesVersion = '17.1.0'
+    lifecycleVersion = '2.0.0'
     daggerVersion = '2.20'
     retrofitVersion = '2.4.0'
     okHttpVersion = '3.11.0'
@@ -148,7 +153,7 @@ dependencies {
     // Need this because of Kotlin
 
     // Android/Google libraries
-    implementation 'androidx.core:core-ktx:1.0.1'
+    implementation 'androidx.core:core-ktx:1.0.2'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation "androidx.appcompat:appcompat:$appCompatVersion"
     implementation "androidx.recyclerview:recyclerview:$supportVersion"
@@ -159,9 +164,9 @@ dependencies {
 
     implementation "com.google.android.gms:play-services-base:$playServicesVersion"
 
-    implementation 'androidx.lifecycle:lifecycle-runtime:2.0.0'
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
-    kapt 'androidx.lifecycle:lifecycle-compiler:2.0.0'
+    implementation "androidx.lifecycle:lifecycle-runtime:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycleVersion"
 
     // App architecture - Dagger 2
     implementation "com.google.dagger:dagger:$daggerVersion"


### PR DESCRIPTION
- Add and update JVM Target to 1.8 for Kotlin projects
- update miscellaneous dependency versions
  - Google play 16.1.0 -> 17.1.0
  - Core-ktx 1.1.0 -> 1.2.0
  - Lifecycle

