### PR TITLE
Feature/dependency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,6 @@ the organization settings, and then get the keys and secrets it displays.
 To see what the dependency tree currently looks like:
 - `./gradlew app:dependencies`
 
-To see what dependencies might be out of date:
-- `./gradlew app:dependencyUpdates -Drevision=release`
-- Note: This has been hit and miss lately. You can also check Lint for obsolete dependency warnings.
-
 ## Continuous Integration Setup
 
 These are written in the context of a TeamCity CI setup.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,21 +117,34 @@ ext {
     supportVersion = '1.0.0'
     playServicesVersion = '17.6.0'
     lifecycleVersion = '2.0.0'
+    lifecycleRuntimeVersion = '2.4.0'
     koinVersion = '3.1.4'
     retrofitVersion = '2.9.0'
-    okHttpVersion = '5.0.0-alpha.3'
+    okHttpVersion = '4.9.1'
     moshiVersion = '1.13.0'
+    coreVersion = '1.7.0'
+    constraintLayoutVersion = '2.1.2'
+    recyclerViewVersion = '1.2.1'
+    materialVersion = '1.4.0'
+    rxJavaVersion = '2.2.21'
+    rxAndroidVersion = '2.1.1'
+    timberVersion = '5.0.1'
+    leakCanaryVersion = '2.7'
 
     // Test dependency versions
     mockitoVersion = '4.1.0'
+    mockitoKotlinVersion = '1.6.0'
     robolectricVersion = '4.7.3'
     androidTestSupportVersion = '1.4.0'
-    espressoVersion = '3.5.0-alpha03'
+    espressoVersion = '3.4.0'
+    junitVersion = '4.13.2'
+    junitTestVersion = '1.1.3'
+    daggerMockVersion = '0.8.4'
 }
 
 dependencies {
     implementation platform("com.google.firebase:firebase-bom:$rootProject.ext.firebase_bom_version")
-    implementation 'com.google.firebase:firebase-analytics-ktx'
+    implementation "com.google.firebase:firebase-analytics-ktx"
 
     // Add the Firebase Crashlytics SDK.
     implementation "com.google.firebase:firebase-crashlytics:$rootProject.ext.firebase_crashlytics_version"
@@ -145,17 +158,17 @@ dependencies {
     // Need this because of Kotlin
 
     // Android/Google libraries
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
+    implementation "androidx.core:core-ktx:$coreVersion"
+    implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
     implementation "androidx.appcompat:appcompat:$appCompatVersion"
-    implementation "androidx.recyclerview:recyclerview:1.2.1"
+    implementation "androidx.recyclerview:recyclerview:$recyclerViewVersion"
     implementation "androidx.cardview:cardview:$supportVersion"
     implementation "androidx.annotation:annotation:$supportVersion"
-    implementation "com.google.android.material:material:1.4.0"
+    implementation "com.google.android.material:material:$materialVersion"
 
     implementation "com.google.android.gms:play-services-base:$playServicesVersion"
 
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleRuntimeVersion"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycleVersion"
 
@@ -163,16 +176,16 @@ dependencies {
     implementation "io.insert-koin:koin-android:$koinVersion"
 
     // App architecture - RxJava
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.21'
-    implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
+    implementation "io.reactivex.rxjava2:rxjava:$rxJavaVersion"
+    implementation "io.reactivex.rxjava2:rxandroid:$rxAndroidVersion"
 
     // JSON
     implementation "com.squareup.moshi:moshi-kotlin:$moshiVersion"
     kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
 
     // Navigation
-    implementation "android.arch.navigation:navigation-fragment-ktx:${navigation_version}"
-    implementation "android.arch.navigation:navigation-ui-ktx:${navigation_version}"
+    implementation "android.arch.navigation:navigation-fragment-ktx:$navigation_version"
+    implementation "android.arch.navigation:navigation-ui-ktx:$navigation_version"
 
     // Networking - HTTP
     implementation "com.squareup.okhttp3:okhttp:$okHttpVersion"
@@ -184,19 +197,19 @@ dependencies {
     implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
 
     // Monitoring - Timber (logging)
-    implementation 'com.jakewharton.timber:timber:5.0.1'
+    implementation "com.jakewharton.timber:timber:$timberVersion"
 
     // Monitoring - Leak Canary
-    debugImplementation "com.squareup.leakcanary:leakcanary-android:2.7"
+    debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
 
     // Unit test
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation "junit:junit:$junitVersion"
     testImplementation "androidx.test:rules:$androidTestSupportVersion"
     testImplementation "androidx.test:core:$androidTestSupportVersion"
-    testImplementation "androidx.test.ext:junit:1.1.3"
+    testImplementation "androidx.test.ext:junit:$junitTestVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
-    testImplementation "com.nhaarman:mockito-kotlin-kt1.1:1.6.0"
+    testImplementation "com.nhaarman:mockito-kotlin-kt1.1:$mockitoKotlinVersion"
     testImplementation "com.squareup.okhttp3:mockwebserver:$okHttpVersion"
 
 
@@ -204,13 +217,13 @@ dependencies {
     androidTestImplementation "androidx.test:runner:$androidTestSupportVersion"
     androidTestImplementation "androidx.test:rules:$androidTestSupportVersion"
     androidTestImplementation "androidx.test:core:$androidTestSupportVersion"
-    androidTestImplementation "androidx.test.ext:junit:1.1.3"
+    androidTestImplementation "androidx.test.ext:junit:$junitTestVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
     androidTestImplementation "androidx.test.espresso:espresso-contrib:$espressoVersion"
 
     androidTestImplementation "org.mockito:mockito-android:$mockitoVersion"
-    androidTestImplementation "com.nhaarman:mockito-kotlin-kt1.1:1.6.0"
-    androidTestImplementation 'com.github.fabioCollini:DaggerMock:0.8.4'
+    androidTestImplementation "com.nhaarman:mockito-kotlin-kt1.1:$mockitoKotlinVersion"
+    androidTestImplementation "com.github.fabioCollini:DaggerMock:$daggerMockVersion"
 }
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,10 +3,6 @@ buildscript {
         google()
         mavenCentral()
     }
-
-    dependencies {
-        classpath 'com.jakewharton.hugo:hugo-plugin:1.2.1'
-    }
 }
 
 repositories {
@@ -21,7 +17,6 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-allopen'
 apply plugin: 'kotlin-parcelize'
 
-apply plugin: 'com.jakewharton.hugo'
 apply plugin: 'com.google.firebase.crashlytics'
 
 apply plugin: 'pmd'
@@ -125,7 +120,7 @@ ext {
     koinVersion = '3.1.4'
     retrofitVersion = '2.9.0'
     okHttpVersion = '5.0.0-alpha.3'
-    moshiVersion = '1.12.0'
+    moshiVersion = '1.13.0'
 
     // Test dependency versions
     mockitoVersion = '4.1.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,11 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
         classpath 'com.jakewharton.hugo:hugo-plugin:1.2.1'
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
     }
 }
 
@@ -20,7 +19,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-allopen'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 
 apply plugin: 'com.jakewharton.hugo'
 apply plugin: 'com.google.firebase.crashlytics'
@@ -28,8 +27,6 @@ apply plugin: 'com.google.firebase.crashlytics'
 apply plugin: 'pmd'
 apply plugin: 'checkstyle'
 apply plugin: 'jacoco'
-
-apply plugin: 'com.github.ben-manes.versions'
 
 android {
     compileOptions {
@@ -119,31 +116,22 @@ android {
     }
 }
 
-androidExtensions {
-    // Needed for Kotlin Parcelable support
-    experimental = true
-
-    // Prevents a bunch of other stuff from being generated
-    defaultCacheImplementation = "none"
-}
-
 ext {
     // App dependency versions
-    appCompatVersion = '1.0.2'
+    appCompatVersion = '1.4.0'
     supportVersion = '1.0.0'
-    playServicesVersion = '17.1.0'
+    playServicesVersion = '17.6.0'
     lifecycleVersion = '2.0.0'
-    koinVersion = '3.1.2'
-    retrofitVersion = '2.4.0'
-    okHttpVersion = '3.11.0'
-    leakcanaryVersion = '1.5.4'
+    koinVersion = '3.1.4'
+    retrofitVersion = '2.9.0'
+    okHttpVersion = '5.0.0-alpha.3'
     moshiVersion = '1.12.0'
 
     // Test dependency versions
-    mockitoVersion = '2.25.0'
-    robolectricVersion = '4.2'
-    androidTestSupportVersion = '1.1.0'
-    espressoVersion = '3.1.0-alpha4'
+    mockitoVersion = '4.1.0'
+    robolectricVersion = '4.7.3'
+    androidTestSupportVersion = '1.4.0'
+    espressoVersion = '3.5.0-alpha03'
 }
 
 dependencies {
@@ -162,17 +150,17 @@ dependencies {
     // Need this because of Kotlin
 
     // Android/Google libraries
-    implementation 'androidx.core:core-ktx:1.0.2'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
     implementation "androidx.appcompat:appcompat:$appCompatVersion"
-    implementation "androidx.recyclerview:recyclerview:$supportVersion"
+    implementation "androidx.recyclerview:recyclerview:1.2.1"
     implementation "androidx.cardview:cardview:$supportVersion"
     implementation "androidx.annotation:annotation:$supportVersion"
-    implementation "com.google.android.material:material:$supportVersion"
+    implementation "com.google.android.material:material:1.4.0"
 
     implementation "com.google.android.gms:play-services-base:$playServicesVersion"
 
-    implementation "androidx.lifecycle:lifecycle-runtime:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycleVersion"
 
@@ -180,7 +168,7 @@ dependencies {
     implementation "io.insert-koin:koin-android:$koinVersion"
 
     // App architecture - RxJava
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.7'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.21'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
 
     // JSON
@@ -197,24 +185,23 @@ dependencies {
 
     // Networking - REST
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
-    implementation "com.squareup.retrofit2:adapter-rxjava2:2.4.0"
+    implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
 
     // Monitoring - Timber (logging)
-    implementation 'com.jakewharton.timber:timber:4.7.0'
+    implementation 'com.jakewharton.timber:timber:5.0.1'
 
     // Monitoring - Leak Canary
-    debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakcanaryVersion"
-    releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$leakcanaryVersion"
+    debugImplementation "com.squareup.leakcanary:leakcanary-android:2.7"
 
     // Unit test
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation "androidx.test:rules:$androidTestSupportVersion"
     testImplementation "androidx.test:core:$androidTestSupportVersion"
-    testImplementation "androidx.test.ext:junit:$androidTestSupportVersion"
-    testImplementation 'org.robolectric:robolectric:4.2'
+    testImplementation "androidx.test.ext:junit:1.1.3"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
-    testImplementation "com.nhaarman:mockito-kotlin-kt1.1:1.5.0"
+    testImplementation "com.nhaarman:mockito-kotlin-kt1.1:1.6.0"
     testImplementation "com.squareup.okhttp3:mockwebserver:$okHttpVersion"
 
 
@@ -222,12 +209,12 @@ dependencies {
     androidTestImplementation "androidx.test:runner:$androidTestSupportVersion"
     androidTestImplementation "androidx.test:rules:$androidTestSupportVersion"
     androidTestImplementation "androidx.test:core:$androidTestSupportVersion"
-    androidTestImplementation "androidx.test.ext:junit:$androidTestSupportVersion"
+    androidTestImplementation "androidx.test.ext:junit:1.1.3"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
     androidTestImplementation "androidx.test.espresso:espresso-contrib:$espressoVersion"
 
     androidTestImplementation "org.mockito:mockito-android:$mockitoVersion"
-    androidTestImplementation "com.nhaarman:mockito-kotlin-kt1.1:1.5.0"
+    androidTestImplementation "com.nhaarman:mockito-kotlin-kt1.1:1.6.0"
     androidTestImplementation 'com.github.fabioCollini:DaggerMock:0.8.4'
 }
 
@@ -265,6 +252,7 @@ jacoco {
 
 tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
+    jacoco.excludes = ['jdk.internal.*']
 }
 
 task jacocoTestReport(type: JacocoReport, dependsOn: ['testDevDebugUnitTest', 'createDevDebugCoverageReport']) {

--- a/app/src/dev/AndroidManifest.xml
+++ b/app/src/dev/AndroidManifest.xml
@@ -9,7 +9,8 @@
             android:name="com.atomicrobot.carbon.ui.devsettings.DevSettingsActivity"
             android:label="@string/dev_settings"
             android:theme="@style/AppTheme.NoActionBar"
-            android:taskAffinity="com.atomicrobot.carbon.dev_settings">
+            android:taskAffinity="com.atomicrobot.carbon.dev_settings"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/dev/java/com/atomicrobot/carbon/ui/devsettings/DevSettingsViewModel.kt
+++ b/app/src/dev/java/com/atomicrobot/carbon/ui/devsettings/DevSettingsViewModel.kt
@@ -6,8 +6,7 @@ import androidx.databinding.Bindable
 import com.atomicrobot.carbon.BR
 import com.atomicrobot.carbon.app.Settings
 import com.atomicrobot.carbon.ui.BaseViewModel
-import kotlinx.android.parcel.Parcelize
-import javax.inject.Inject
+import kotlinx.parcelize.Parcelize
 
 class DevSettingsViewModel(
         private val app: Application,

--- a/app/src/dev/res/layout/content_dev_settings.xml
+++ b/app/src/dev/res/layout/content_dev_settings.xml
@@ -1,4 +1,4 @@
-<fragment
+<androidx.fragment.app.FragmentContainerView
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:name="com.atomicrobot.carbon.ui.devsettings.DevSettingsFragment"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
             android:name="com.atomicrobot.carbon.StartActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar"
-            android:windowSoftInputMode="stateHidden">
+            android:windowSoftInputMode="stateHidden"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/atomicrobot/carbon/app/BaseApplicationInitializer.kt
+++ b/app/src/main/java/com/atomicrobot/carbon/app/BaseApplicationInitializer.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.gms.security.ProviderInstaller
 import com.google.android.gms.security.ProviderInstaller.ProviderInstallListener
-import com.squareup.leakcanary.LeakCanary
 
 import timber.log.Timber
 import timber.log.Timber.Tree
@@ -16,8 +15,6 @@ abstract class BaseApplicationInitializer(
         private val logger: Tree) {
 
     open fun initialize() {
-        LeakCanary.install(application)
-
         Timber.plant(logger)
 
         upgradeSecurityProvider()
@@ -29,7 +26,7 @@ abstract class BaseApplicationInitializer(
 
             }
 
-            override fun onProviderInstallFailed(errorCode: Int, recoveryIntent: Intent) {
+            override fun onProviderInstallFailed(errorCode: Int, recoveryIntent: Intent?) {
                 GoogleApiAvailability.getInstance().showErrorNotification(application, errorCode)
             }
         })

--- a/app/src/main/java/com/atomicrobot/carbon/data/DataModule.kt
+++ b/app/src/main/java/com/atomicrobot/carbon/data/DataModule.kt
@@ -1,6 +1,7 @@
 package com.atomicrobot.carbon.data
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import com.atomicrobot.carbon.app.Settings
 import com.atomicrobot.carbon.data.api.github.GitHubApiService
 import com.atomicrobot.carbon.data.api.github.GitHubInteractor
@@ -97,7 +98,8 @@ class DataModule {
         return settings.baseUrl
     }
 
-    private fun provideRetrofit(
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun provideRetrofit(
         client: OkHttpClient,
         baseUrl: String,
         converterFactory: Converter.Factory
@@ -110,7 +112,8 @@ class DataModule {
             .build()
     }
 
-    private fun provideGitHubApiService(retrofit: Retrofit): GitHubApiService {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun provideGitHubApiService(retrofit: Retrofit): GitHubApiService {
         return retrofit.create(GitHubApiService::class.java)
     }
 

--- a/app/src/main/java/com/atomicrobot/carbon/ui/BaseFragment.kt
+++ b/app/src/main/java/com/atomicrobot/carbon/ui/BaseFragment.kt
@@ -2,11 +2,11 @@ package com.atomicrobot.carbon.ui
 
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import kotlin.reflect.KClass
 
 abstract class BaseFragment: Fragment() {
     fun <VM: ViewModel> getViewModel(viewModelClass: KClass<VM>): VM {
-        return ViewModelProviders.of(activity!!).get(viewModelClass.java)
+        return ViewModelProvider(requireActivity()).get(viewModelClass.java)
     }
 }

--- a/app/src/main/java/com/atomicrobot/carbon/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/atomicrobot/carbon/ui/main/MainViewModel.kt
@@ -15,9 +15,7 @@ import com.atomicrobot.carbon.ui.SimpleSnackbarMessage
 import com.atomicrobot.carbon.util.RxUtils.delayAtLeast
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.parcel.Parcelize
-import javax.inject.Inject
-import javax.inject.Named
+import kotlinx.parcelize.Parcelize
 
 class MainViewModel(
         private val app: Application,
@@ -54,7 +52,8 @@ class MainViewModel(
 
             when (value) {
                 is Commits.Error -> snackbarMessage.value = value.message
-                else -> {}
+                is Commits.Result -> {}
+                Commits.Loading -> {}
             }
         }
 

--- a/app/src/main/java/com/atomicrobot/carbon/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/atomicrobot/carbon/ui/main/MainViewModel.kt
@@ -54,6 +54,7 @@ class MainViewModel(
 
             when (value) {
                 is Commits.Error -> snackbarMessage.value = value.message
+                else -> {}
             }
         }
 

--- a/app/src/main/java/com/atomicrobot/carbon/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/atomicrobot/carbon/ui/splash/SplashViewModel.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import android.os.Parcelable
 import com.atomicrobot.carbon.ui.BaseViewModel
 import com.atomicrobot.carbon.ui.NavigationEvent
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 class SplashViewModel @Inject constructor(

--- a/app/src/main/java/com/atomicrobot/carbon/util/AppLogger.kt
+++ b/app/src/main/java/com/atomicrobot/carbon/util/AppLogger.kt
@@ -11,7 +11,7 @@ class AppLogger : Logger() {
             Level.DEBUG -> Timber.d(msg)
             Level.ERROR -> Timber.e(msg)
             Level.INFO -> Timber.i(msg)
-            else -> {}
+            Level.NONE -> {}
         }
     }
 }

--- a/app/src/main/java/com/atomicrobot/carbon/util/AppLogger.kt
+++ b/app/src/main/java/com/atomicrobot/carbon/util/AppLogger.kt
@@ -11,6 +11,7 @@ class AppLogger : Logger() {
             Level.DEBUG -> Timber.d(msg)
             Level.ERROR -> Timber.e(msg)
             Level.INFO -> Timber.i(msg)
+            else -> {}
         }
     }
 }

--- a/app/src/main/res/layout/activity_start.xml
+++ b/app/src/main/res/layout/activity_start.xml
@@ -10,7 +10,7 @@
         android:fitsSystemWindows="true"
         tools:context="com.atomicrobot.carbon.StartActivity">
 
-        <fragment
+        <androidx.fragment.app.FragmentContainerView
             android:id="@+id/nav_host_fragment"
             android:name="androidx.navigation.fragment.NavHostFragment"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -1,4 +1,4 @@
-<fragment
+<androidx.fragment.app.FragmentContainerView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:name="com.atomicrobot.carbon.ui.main.MainFragment"

--- a/app/src/test/java/com/atomicrobot/carbon/TestExtensions.kt
+++ b/app/src/test/java/com/atomicrobot/carbon/TestExtensions.kt
@@ -1,6 +1,7 @@
 package com.atomicrobot.carbon
 
-import okio.Okio
+import okio.buffer
+import okio.source
 import java.io.File
 import java.nio.charset.Charset
 
@@ -10,5 +11,5 @@ object TestExtensions
 fun String.loadResourceAsString(): String {
     val url = TestExtensions::class.java.getResource(this)
     val file = File(url.file)
-    return Okio.buffer(Okio.source(file)).readString(Charset.forName("UTF-8"))
+    return file.source().buffer().readString(Charset.forName("UTF-8"))
 }

--- a/app/src/test/java/com/atomicrobot/carbon/data/api/github/GitHubApiServiceTest.kt
+++ b/app/src/test/java/com/atomicrobot/carbon/data/api/github/GitHubApiServiceTest.kt
@@ -1,9 +1,10 @@
 package com.atomicrobot.carbon.data.api.github
 
 import com.atomicrobot.carbon.data.DataModule
-import com.atomicrobot.carbon.data.api.github.GitHubApiService
 import com.atomicrobot.carbon.data.api.github.model.Commit
 import com.atomicrobot.carbon.loadResourceAsString
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.reactivex.observers.TestObserver
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -12,7 +13,10 @@ import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import org.mockito.MockitoAnnotations
+import retrofit2.Converter
 import retrofit2.Response
+import retrofit2.converter.moshi.MoshiConverterFactory
 import java.net.UnknownHostException
 import java.util.concurrent.TimeUnit
 
@@ -22,6 +26,7 @@ class GitHubApiServiceTest {
 
     @Before
     fun setup() {
+        MockitoAnnotations.initMocks(this)
         server = MockWebServer()
     }
 
@@ -102,7 +107,9 @@ class GitHubApiServiceTest {
     private fun buildApi(baseUrl: String): GitHubApiService {
         val module = DataModule()
         val client = OkHttpClient.Builder().build()
-        val converterFactory = module.provideConverter()
+        // TODO - fix with koin tests?
+        val moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
+        val converterFactory = MoshiConverterFactory.create(moshi) as Converter.Factory
         val retrofit = module.provideRetrofit(client, baseUrl, converterFactory)
         return module.provideGitHubApiService(retrofit)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,17 @@
 buildscript {
     ext.android_plugin_version = '4.2.1'
-    ext.kotlin_version = '1.5.10'
-    ext.jacoco_version = '0.8.1'
+    ext.kotlin_version = '1.5.31'
+    ext.jacoco_version = '0.8.6'
     ext.navigation_version = '1.0.0'
     ext.firebase_bom_version = '28.0.0'
-    ext.firebase_crashlytics_version = '18.0.0'
-    ext.firebase_analytics_version = '19.0.0'
+    ext.firebase_crashlytics_version = '18.2.5'
+    ext.firebase_analytics_version = '20.0.0'
     ext.google_services_version = '4.3.8'
     ext.firebase_crashlytics_gradle_version = '2.6.1'
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -29,7 +29,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
         maven { url "https://jitpack.io" }
     }
@@ -85,8 +84,8 @@ ext {
 
     // Build settings that are likely to be reused across different modules
     minSdkVersion = 21
-    targetSdkVersion = 28
-    compileSdkVersion = 28
+    targetSdkVersion = 31
+    compileSdkVersion = 31
 }
 
 evaluationDependsOnChildren()

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-    ext.android_plugin_version = '4.2.1'
-    ext.kotlin_version = '1.5.31'
+    ext.android_plugin_version = '7.0.4'
+    ext.kotlin_version = '1.6.0'
     ext.jacoco_version = '0.8.6'
     ext.navigation_version = '1.0.0'
     ext.firebase_bom_version = '28.0.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,6 @@ org.gradle.configureondemand=false
 org.gradle.parallel=true
 
 org.gradle.caching=true
-android.enableBuildCache=true
 
 org.gradle.warning.mode=summary
 android.useAndroidX=true
@@ -13,4 +12,4 @@ android.enableJetifier=true
 
 android.enableUnitTestBinaryResources=false
 
-android.jetifier.blacklist=bcprov-jdk15on
+android.jetifier.ignorelist=bcprov-jdk15on

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 android.enableUnitTestBinaryResources=false
+
+android.jetifier.blacklist=bcprov-jdk15on

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip


### PR DESCRIPTION
# Changelog
Includes a comprehensive update of all dependencies in the application to their latest stable versions, as well as the removal of the JCenter repository (no longer updated as of March 31st, 2021) in favor of MavenCentral

Adjusted Target & Compile SDK Versions to the latest, API 31 and addressed issues associated with that change.

Made minor code adjustments using Kotlin Migrations tool in preparation for Kotlin 1.7 (ex. non-exhaustive when statements will be an error in 1.7)

## Added
- android:exported parameter to manifest (required in API 31)
- kotlin-parcelize dependency (to keep Parcelize functionality in lieu of kotlin-android-extensions deprecation)

## Changed
- Updated targetSdkVersion to 31
- Updated compileSdkVersion to 31
- Updated Android Gradle Plugin Version to 7.0.4 (previously 4.2.1)
- Updated Kotlin Version to 1.6.0 (previously 1.5.10)
- All dependencies to latest stable releases (see build.gradle and app/build.gradle)

## Removed
- Ben Manes Gradle Versions Plugin (used for checking out of date dependencies, but Android Studio already does this with  the Lint checker)
- Jake Wharton's Hugo Plugin (an "Annotation-triggered method call logging for your debug builds". Currently this is completely unused. The feature would be nice but hasn't been updated since 2016 and is not compatible with newer AGP version)
- kotlin-android-extensions dependency (deprecated)
- Leak Canary initialization (no longer required to initialize in LeakCanary2, it just works)
- android.enableBuildCache parameter from gradle.properties (deprecated - use org.gradle.caching instead per Android Developer docs)

## Is there test coverage for your changes?
  Yes, the unit tests were updated to support koin changes, but instrumented tests are still broken (complaints about Dagger)
